### PR TITLE
Fix dependency to drupal/rng

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,6 @@
   ],
   "license": "GPL-2.0+",
   "require": {
-    "drupal/rng": "~8.0"
+    "drupal/rng": "^1.0"
   }
 }


### PR DESCRIPTION
The current dependency is invalid ~8.0 can refer to core but not to a module.